### PR TITLE
fix: Forward native error details to webview

### DIFF
--- a/.changeset/wicked-bugs-happen.md
+++ b/.changeset/wicked-bugs-happen.md
@@ -1,0 +1,7 @@
+---
+"@webview-bridge/react-native": patch
+"@webview-bridge/utils": patch
+"@webview-bridge/web": patch
+---
+
+fix: Forward native error details to webview

--- a/example/native-method/react-native/App.tsx
+++ b/example/native-method/react-native/App.tsx
@@ -16,6 +16,9 @@ export const appBridge = bridge({
       await InAppBrowser.open(url);
     }
   },
+  async throwError() {
+    throw new Error('🚧 This error is from native side!!');
+  },
 });
 
 

--- a/example/native-method/react/src/App.tsx
+++ b/example/native-method/react/src/App.tsx
@@ -15,6 +15,7 @@ const bridge = linkBridge<AppBridge>({
 
 function App() {
   const [message, setMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
 
   useEffect(() => {
     async function init() {
@@ -38,6 +39,27 @@ function App() {
       >
         open InAppBrowser
       </button>
+
+      <button
+        style={{ marginTop: 8 }}
+        onClick={async () => {
+          try {
+            await bridge.throwError();
+          } catch (err) {
+            if (err instanceof Error) {
+              setErrorMessage(err.message);
+            }
+          }
+        }}
+      >
+        Test Error from Native
+      </button>
+
+      {errorMessage && (
+        <div style={{ marginTop: 16, padding: 12, background: "#fee", border: "1px solid red" }}>
+          <strong>Error caught: </strong>{errorMessage}
+        </div>
+      )}
 
       <div>
         {`isWebViewBridgeAvailable: ${String(bridge.isWebViewBridgeAvailable)}`}

--- a/example/native-method/web/src/main.ts
+++ b/example/native-method/web/src/main.ts
@@ -2,7 +2,9 @@ import "./style.css";
 import { linkBridge } from "@webview-bridge/web";
 import type { AppBridge } from "@webview-bridge-example-native-method/react-native/types";
 
-const bridge = linkBridge<AppBridge>();
+const bridge = linkBridge<AppBridge>({
+  throwOnError: true,
+});
 
 document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
    <div>
@@ -11,9 +13,17 @@ document.querySelector<HTMLDivElement>("#app")!.innerHTML = `
       <button id="btn">
         open InAppBrowser
       </button>
+      <button id="btn-error" style="margin-top: 8px;">
+        Test Error from Native
+      </button>
 
       <div>
         isWebViewBridgeAvailable: ${String(bridge.isWebViewBridgeAvailable)}
+      </div>
+
+      <div id="error-result" style="margin-top: 16px; padding: 12px; background: #fee; border: 1px solid #f00; display: none;">
+        <strong>Error caught:</strong>
+        <pre id="error-detail" style="white-space: pre-wrap;"></pre>
       </div>
     </div>
 `;
@@ -22,6 +32,21 @@ const run = async () => {
   document.getElementById("btn")!.addEventListener("click", async () => {
     if (bridge.isNativeMethodAvailable("openInAppBrowser")) {
       await bridge.openInAppBrowser("https://github.com/gronxb/webview-bridge");
+    }
+  });
+
+  document.getElementById("btn-error")!.addEventListener("click", async () => {
+    const resultEl = document.getElementById("error-result")!;
+    const detailEl = document.getElementById("error-detail")!;
+    try {
+      await bridge.throwError();
+    } catch (error) {
+      resultEl.style.display = "block";
+      if (error instanceof Error) {
+        detailEl.textContent = `name: ${error.name}\nmessage: ${error.message}\nstack: ${error.stack ?? "N/A"}`;
+      } else {
+        detailEl.textContent = `Non-Error caught: ${String(error)}`;
+      }
     }
   });
 

--- a/packages/react-native/src/error.ts
+++ b/packages/react-native/src/error.ts
@@ -4,3 +4,17 @@ export class WebMethodError extends Error {
     this.name = "WebMethodError";
   }
 }
+
+export function serializeError(error: Error) {
+  return JSON.stringify(error, (_, value) => {
+    if (value instanceof Error) {
+      return {
+        name: value.name,
+        message: value.message,
+        stack: value.stack,
+        __isError: true,
+      };
+    }
+    return value;
+  });
+}

--- a/packages/utils/src/createEvents.ts
+++ b/packages/utils/src/createEvents.ts
@@ -49,7 +49,7 @@ export interface CreateResolverOptions {
   emitter: DefaultEmitter;
   evaluate: () => void;
   eventId: string;
-  failHandler?: Error | ErrorConstructor | false;
+  failHandler?: Error | false;
   methodName: string;
   onFallback?: () => void;
 }

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -9,10 +9,12 @@ export const deserializeError = (
   value: any,
   ErrorConstructor: ErrorConstructor = Error,
 ) => {
-  if (value?.__isError) {
-    const err = new ErrorConstructor(value.message);
-    err.name = value.name;
-    err.stack = value.stack;
+  const parsed = typeof value === "string" ? JSON.parse(value) : value;
+
+  if (parsed?.__isError) {
+    const err = new ErrorConstructor(parsed.message);
+    err.name = parsed.name;
+    err.stack = parsed.stack;
     return err;
   }
   return value;

--- a/packages/utils/src/errors.ts
+++ b/packages/utils/src/errors.ts
@@ -1,0 +1,19 @@
+export class NativeMethodError extends Error {
+  constructor(methodName: string) {
+    super(`An error occurred in the native bridge: ${methodName}`);
+    this.name = "NativeMethodError";
+  }
+}
+
+export const deserializeError = (
+  value: any,
+  ErrorConstructor: ErrorConstructor = Error,
+) => {
+  if (value?.__isError) {
+    const err = new ErrorConstructor(value.message);
+    err.name = value.name;
+    err.stack = value.stack;
+    return err;
+  }
+  return value;
+};

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -4,3 +4,4 @@ export * from "./equals";
 export * from "./noop";
 export * from "./removeUndefinedKeys";
 export * from "./timeout";
+export * from "./errors";

--- a/packages/web/src/error.ts
+++ b/packages/web/src/error.ts
@@ -4,10 +4,3 @@ export class MethodNotFoundError extends Error {
     this.name = "MethodNotFoundError";
   }
 }
-
-export class NativeMethodError extends Error {
-  constructor(methodName: string) {
-    super(`An error occurred in the native bridge: ${methodName}`);
-    this.name = "NativeMethodError";
-  }
-}

--- a/packages/web/src/internal/bridgeInstance.ts
+++ b/packages/web/src/internal/bridgeInstance.ts
@@ -111,7 +111,7 @@ export class BridgeInstance<
             onFallback: () => {
               onFallback?.(methodName, args);
             },
-            failHandler: throwOnError && NativeMethodError,
+             failHandler: throwOnError && new NativeMethodError(methodName),
           }),
           timeoutMs > 0 && timeout(timeoutMs, throwOnError),
         ].filter(Boolean),

--- a/packages/web/src/internal/bridgeInstance.ts
+++ b/packages/web/src/internal/bridgeInstance.ts
@@ -9,12 +9,12 @@ import type {
 } from "@webview-bridge/types";
 import {
   type DefaultEmitter,
+  NativeMethodError,
   createRandomId,
   createResolver,
   timeout,
 } from "@webview-bridge/utils";
 
-import { NativeMethodError } from "../error";
 import type { LinkBridgeOptions } from "../linkBridge";
 import type { LinkBridge } from "../types";
 import { createPromiseProxy } from "./createPromiseProxy";
@@ -111,7 +111,7 @@ export class BridgeInstance<
             onFallback: () => {
               onFallback?.(methodName, args);
             },
-            failHandler: throwOnError && new NativeMethodError(methodName),
+            failHandler: throwOnError && NativeMethodError,
           }),
           timeoutMs > 0 && timeout(timeoutMs, throwOnError),
         ].filter(Boolean),

--- a/packages/web/src/internal/bridgeInstance.ts
+++ b/packages/web/src/internal/bridgeInstance.ts
@@ -111,7 +111,7 @@ export class BridgeInstance<
             onFallback: () => {
               onFallback?.(methodName, args);
             },
-             failHandler: throwOnError && new NativeMethodError(methodName),
+            failHandler: throwOnError && new NativeMethodError(methodName),
           }),
           timeoutMs > 0 && timeout(timeoutMs, throwOnError),
         ].filter(Boolean),

--- a/packages/web/src/linkBridge.ts
+++ b/packages/web/src/linkBridge.ts
@@ -82,7 +82,8 @@ export const linkBridge = <
       ([methodName]) => methodName,
     );
     return {
-      addEventListener: (_eventName, _listener) => () => {},
+      addEventListener:
+        (_eventName: string, _listener: (...args: any[]) => void) => () => {},
       loose: {},
       isWebViewBridgeAvailable: initialBridgeMethodNames.length > 0,
       isNativeMethodAvailable: (method: string) =>

--- a/packages/web/src/linkBridge.ts
+++ b/packages/web/src/linkBridge.ts
@@ -82,8 +82,7 @@ export const linkBridge = <
       ([methodName]) => methodName,
     );
     return {
-      addEventListener:
-        (_eventName: string, _listener: (...args: any[]) => void) => () => {},
+      addEventListener: (_eventName, _listener) => () => {},
       loose: {},
       isWebViewBridgeAvailable: initialBridgeMethodNames.length > 0,
       isNativeMethodAvailable: (method: string) =>


### PR DESCRIPTION
**Summary**
- Native errors now forward actual error details (message, name, stack) to webview
- Previously only generic NativeMethodError was received

**Changes**
- Add serializeError / deserializeError to pass error details between native and web
- Fix deserializeError to parse JSON string from native


**Before**

https://github.com/user-attachments/assets/f16a7482-9d56-422a-971d-c750ba3c5fe2


**After**

https://github.com/user-attachments/assets/4c5e7f54-10b0-48e7-aa3d-18775812dcba

## Note
Added `throwError` test method in example/native-method folder for testing. 
Let me know if this should be removed.

Closes #98