### PR TITLE
fix(docs): correct broken link to generate-declaration-file page

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -52,7 +52,7 @@ You need to export the created `typeof appBridge` and share its type with the we
 **For detailed guides, visit:**   
 Monorepo setup: [Exporting Type Declarations in a Monorepo](https://gronxb.github.io/webview-bridge/exporting-type-declarations/monorepo.html)  
 Custom declaration file: [Exporting Type Declarations with a Custom Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/custom-declaration-file.html)  
-Generate declaration file: [Exporting Type Declarations with a Generate Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/generate-declaration-type.html)
+Generate declaration file: [Exporting Type Declarations with a Generate Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/generate-declaration-file.html)
 :::
 
 ```tsx

--- a/docs/using-a-loose-native-method.md
+++ b/docs/using-a-loose-native-method.md
@@ -7,7 +7,7 @@ There is a way to export types to other projects using `dts-bundle-generator`.
 
 **For detailed guides, visit:**   
 Custom declaration file: [Exporting Type Declarations with a Custom Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/custom-declaration-file.html)  
-Generate declaration file: [Exporting Type Declarations with a Generate Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/generate-declaration-type.html)
+Generate declaration file: [Exporting Type Declarations with a Generate Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/generate-declaration-file.html)
 :::
 
 ## React Native Part

--- a/docs/using-a-native-method.md
+++ b/docs/using-a-native-method.md
@@ -12,7 +12,7 @@ You need to export the created `typeof appBridge` and share its type with the we
 **For detailed guides, visit:**   
 Monorepo setup: [Exporting Type Declarations in a Monorepo](https://gronxb.github.io/webview-bridge/exporting-type-declarations/monorepo.html)  
 Custom declaration file: [Exporting Type Declarations with a Custom Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/custom-declaration-file.html)  
-Generate declaration file: [Exporting Type Declarations with a Generate Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/generate-declaration-type.html)
+Generate declaration file: [Exporting Type Declarations with a Generate Declaration File](https://gronxb.github.io/webview-bridge/exporting-type-declarations/generate-declaration-file.html)
 :::
 
 


### PR DESCRIPTION
## Summary
- Fixed broken documentation links that pointed to a non-existent page (`generate-declaration-type.html`)
- The correct page is `generate-declaration-file.html`

## Problem
Clicking the "Exporting Type Declarations with a Generate Declaration File" link on the following pages results in a 404 error:
- `/using-a-native-method.html`
- `/using-a-loose-native-method.html`
- `/getting-started.html`

The links incorrectly referenced `generate-declaration-type.html`, but the actual page is `generate-declaration-file.html`.

## Changes
- `docs/getting-started.md`
- `docs/using-a-native-method.md`
- `docs/using-a-loose-native-method.md`

All three files: `generate-declaration-type.html` → `generate-declaration-file.html`