### PR TITLE
chore(react-native):  metro package export resolution

### DIFF
--- a/.changeset/tough-webviews-smile.md
+++ b/.changeset/tough-webviews-smile.md
@@ -1,0 +1,5 @@
+---
+"@webview-bridge/react-native": patch
+---
+
+Fix Metro compatibility by resolving the React Native source entry before the generic import and require builds.

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -10,6 +10,7 @@
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
+      "react-native": "./src/index.ts",
       "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }


### PR DESCRIPTION
## Summary

- add a `react-native` condition to the root package export map
- keep the existing ESM and CommonJS builds as fallbacks for non-React Native consumers
- add a patch changeset for `@webview-bridge/react-native`

## Root cause

Metro gives `exports` precedence over the legacy top-level `react-native` field. Because the export map did not include a `react-native` condition, Metro could resolve one of the generic prebuilt entries instead of `src/index.ts`. Selecting the CommonJS build exposed an incompatible default-export interop path for `react-native-webview`, causing React to receive a module object instead of the `WebView` component.

## Impact

React Native consumers now resolve the package source entry through the standard `react-native` export condition, restoring the intended Metro-specific resolution without changing runtime source code.

## Validation

- `pnpm --filter @webview-bridge/react-native test:type`
- verified the `react-native` condition resolves to `src/index.ts`
- verified `pnpm changeset status` includes the fixed package group at patch level
