### PR TITLE
feat: add composable bridge middleware

### DIFF
--- a/.changeset/quiet-dingos-guard.md
+++ b/.changeset/quiet-dingos-guard.md
@@ -1,0 +1,6 @@
+---
+"@webview-bridge/react-native": minor
+---
+
+Add chainable `bridge(...).use(middleware)` support for composing Web-to-Native
+request authentication, preprocessing, short-circuiting, and response logic.

--- a/docs/reference/react-native/create-webview.md
+++ b/docs/reference/react-native/create-webview.md
@@ -9,3 +9,37 @@ The `createWebView` is used to create a WebView with an interface that enables c
 | `debug`          | boolean                        | false    | false   | Outputs console.log from the web in React Native.                                          |
 | `responseTimeout`| number                         | false    | 2000    | Timeout duration when executing web methods.                   |
 | `fallback`       | (method: keyof T) => void      | false    | X       |Callback function called when a method from the bridge is not found.         |
+
+## Bridge middleware
+
+`bridge(...).use(...)` registers instance-scoped middleware for Web-to-Native
+method calls.
+
+```tsx
+import {
+  bridge,
+  type BridgeMiddleware,
+} from "@webview-bridge/react-native";
+
+const logger: BridgeMiddleware = async ({ method }, next) => {
+  console.log(`Calling ${method}`);
+  const result = await next();
+  console.log(`Called ${method}`);
+  return result;
+};
+
+const appBridge = bridge({
+  async getMessage() {
+    return "Hello, I'm native";
+  },
+}).use(logger);
+```
+
+Middleware receives `{ url, method, args }` and `next()`. It may update `args`,
+attach typed context fields to the shared request, short-circuit without calling
+`next()`, or transform the returned value.
+`use()` returns the same bridge store for chaining; call `next()` at most once.
+
+`url` is the top-level URL reported by `react-native-webview`, not a verified
+caller origin. Middleware applies only to bridge method calls and does not
+intercept navigation or network requests.

--- a/example/native-method/react-native/App.tsx
+++ b/example/native-method/react-native/App.tsx
@@ -1,26 +1,122 @@
-import React from "react";
-import { SafeAreaView } from "react-native";
+import React from 'react';
+import { SafeAreaView, StyleSheet } from 'react-native';
 import {
   createWebView,
+  type BridgeMiddleware,
+  type BridgeStore,
   type BridgeWebView,
   bridge,
-} from "@webview-bridge/react-native";
-import InAppBrowser from "react-native-inappbrowser-reborn";
+} from '@webview-bridge/react-native';
+import InAppBrowser from 'react-native-inappbrowser-reborn';
+import 'react-native-url-polyfill/auto';
 
-export const appBridge = bridge({
+const WEB_APP_URL = new URL('http://localhost:5173');
+
+const getUrlOrigin = (url: string) => new URL(url).origin;
+
+const observeBridgeRequests = (): BridgeMiddleware =>
+  async ({ method, url }, next) => {
+    const startedAt = Date.now();
+    let origin = 'unknown';
+    try {
+      if (url) {
+        origin = getUrlOrigin(url);
+      }
+    } catch {
+      origin = 'invalid URL';
+    }
+
+    console.log(`[bridge] -> ${method} (${origin})`);
+    try {
+      const result = await next();
+      console.log(`[bridge] <- ${method} (${Date.now() - startedAt}ms)`);
+      return result;
+    } catch (error) {
+      console.error(
+        `[bridge] !! ${method} (${Date.now() - startedAt}ms)`,
+        error,
+      );
+      throw error;
+    }
+  };
+
+const allowWebAppOrigin = (webAppUrl: URL): BridgeMiddleware => {
+  const allowedOrigin = webAppUrl.origin;
+
+  return async ({ url }, next) => {
+    let requestOrigin: string;
+    try {
+      if (!url) {
+        throw new Error('Missing WebView URL');
+      }
+      requestOrigin = getUrlOrigin(url);
+    } catch {
+      throw new Error('Bridge request has an invalid WebView URL');
+    }
+
+    if (requestOrigin !== allowedOrigin) {
+      throw new Error(`Bridge request denied for origin: ${requestOrigin}`);
+    }
+    return next();
+  };
+};
+
+const normalizeExternalUrl = (): BridgeMiddleware =>
+  async (request, next) => {
+    if (request.method !== 'openInAppBrowser') {
+      return next();
+    }
+
+    const [input] = request.args;
+    if (typeof input !== 'string' || input.trim().length === 0) {
+      throw new TypeError('A non-empty URL is required');
+    }
+
+    const trimmedUrl = input.trim();
+    let externalUrl: URL;
+    try {
+      externalUrl = new URL(trimmedUrl);
+    } catch {
+      externalUrl = new URL(`https://${trimmedUrl}`);
+    }
+
+    if (externalUrl.protocol !== 'https:') {
+      throw new Error('Only HTTPS links can be opened');
+    }
+
+    request.args = [externalUrl.toString()];
+    return next();
+  };
+
+const configuredAppBridge = bridge({
   async getMessage() {
     return "I'm from native" as const;
   },
   async openInAppBrowser(url: string) {
-    if (await InAppBrowser.isAvailable()) {
-      await InAppBrowser.open(url);
+    if (!(await InAppBrowser.isAvailable())) {
+      return {
+        openedUrl: url,
+        status: 'unavailable' as const,
+      };
     }
+
+    const result = await InAppBrowser.open(url);
+    return {
+      openedUrl: url,
+      status: result.type,
+    };
   },
   async throwError() {
     throw new Error('🚧 This error is from native side!!');
   },
-});
+})
+  .use(observeBridgeRequests())
+  .use(allowWebAppOrigin(WEB_APP_URL))
+  .use(normalizeExternalUrl());
 
+export const appBridge: BridgeStore<
+  ReturnType<typeof configuredAppBridge.getState>
+> = configuredAppBridge;
 
 export const { WebView } = createWebView({
   bridge: appBridge,
@@ -34,16 +130,27 @@ function App(): JSX.Element {
   const webviewRef = React.useRef<BridgeWebView>(null);
 
   return (
-    <SafeAreaView style={{ height: "100%" }}>
+    <SafeAreaView style={styles.container}>
       <WebView
         ref={webviewRef}
         source={{
-          uri: "http://localhost:5173",
+          uri: WEB_APP_URL.href,
         }}
-        style={{ height: "100%", flex: 1, width: "100%" }}
+        style={styles.webView}
       />
     </SafeAreaView>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    height: '100%',
+  },
+  webView: {
+    flex: 1,
+    width: '100%',
+    height: '100%',
+  },
+});
 
 export default App;

--- a/example/native-method/react-native/README.md
+++ b/example/native-method/react-native/README.md
@@ -1,5 +1,20 @@
 This is a new [**React Native**](https://reactnative.dev) project, bootstrapped using [`@react-native-community/cli`](https://github.com/react-native-community/cli).
 
+## Bridge middleware example
+
+`App.tsx` chains request logging, WebView URL authorization, and external URL
+normalization with `bridge(...).use(...)`. The paired `../react` app exercises
+the chain before opening a real native InAppBrowser.
+
+From the repository root, run the middleware integration tests with:
+
+```bash
+pnpm --filter @webview-bridge-example-native-method/react-native test --runInBand
+```
+
+In the running example, a scheme-less URL is normalized to HTTPS, while the
+**Try blocked scheme** action is rejected before native browser code runs.
+
 # Getting Started
 
 >**Note**: Make sure you have completed the [React Native - Environment Setup](https://reactnative.dev/docs/environment-setup) instructions till "Creating a new application" step, before proceeding.

--- a/example/native-method/react-native/__tests__/bridgeMiddleware.test.ts
+++ b/example/native-method/react-native/__tests__/bridgeMiddleware.test.ts
@@ -1,0 +1,242 @@
+import {
+  bridge,
+  handleBridge,
+  type BridgeMiddleware,
+  type BridgeMiddlewareNext,
+} from '../../../../packages/react-native/src/integrations/bridge';
+import type {BridgeStore} from '@webview-bridge/react-native';
+
+type HandleBridgeStore = Parameters<typeof handleBridge>[0]['bridge'];
+
+const parseEmission = (script: string) => {
+  const call = script.match(/\.emit\('([^']+)', (.+)\);/);
+  if (!call) {
+    throw new Error(`Could not find an emitter call in: ${script}`);
+  }
+  return [call[1], ...JSON.parse(`[${call[2]}]`)] as unknown[];
+};
+
+const invokeBridge = async (
+  bridgeStore: HandleBridgeStore,
+  method: string,
+  args: unknown[] = [],
+) => {
+  const scripts: string[] = [];
+
+  await handleBridge({
+    bridge: bridgeStore,
+    method,
+    args,
+    eventId: 'event',
+    bridgeId: 'example',
+    url: 'https://app.example/screen',
+    webview: {
+      injectJavaScript(script: string) {
+        scripts.push(script);
+      },
+    } as never,
+  });
+
+  expect(scripts).toHaveLength(1);
+  return parseEmission(scripts[0]);
+};
+
+describe('bridge middleware integration', () => {
+  it('remains usable as a legacy BridgeStore when middleware is not used', async () => {
+    const appBridge = bridge({
+      async getMessage() {
+        return 'native value';
+      },
+    });
+    const legacyStore: BridgeStore<ReturnType<typeof appBridge.getState>> =
+      appBridge;
+
+    expect(Object.keys(appBridge)).toEqual([
+      'getState',
+      'setState',
+      'subscribe',
+    ]);
+    await expect(invokeBridge(legacyStore, 'getMessage')).resolves.toEqual([
+      'getMessage-event',
+      'native value',
+    ]);
+  });
+
+  it('chains three middlewares, propagates context, and transforms a response', async () => {
+    const calls: string[] = [];
+    type AuthContext = {auth: {userId: string}};
+    const auth = (): BridgeMiddleware<AuthContext> =>
+      async (request, next) => {
+        calls.push('middleware 1 start');
+        request.auth = {userId: 'user-1'};
+        const response = await next();
+        calls.push('middleware 1 end');
+        return response;
+      };
+    const appBridge = bridge({
+      async openExternalUrl(url: string) {
+        calls.push(`method:${url}`);
+        return { openedUrl: url };
+      },
+    })
+      .use(auth())
+      .use(async (request, next) => {
+        calls.push(`middleware 2 start:${request.auth.userId}`);
+        request.args = [
+          new URL(
+            String(request.args[0]).trim(),
+            'https://example.com',
+          ).toString(),
+        ];
+        const response = (await next()) as { openedUrl: string };
+        calls.push('middleware 2 end');
+        return { ...response, traced: true };
+      })
+      .use(async (request, next) => {
+        calls.push(`middleware 3 start:${request.auth.userId}`);
+        await next();
+        calls.push('middleware 3 end');
+      });
+
+    const emission = await invokeBridge(appBridge, 'openExternalUrl', [
+      '/docs ',
+    ]);
+
+    expect(calls).toEqual([
+      'middleware 1 start',
+      'middleware 2 start:user-1',
+      'middleware 3 start:user-1',
+      'method:https://example.com/docs',
+      'middleware 3 end',
+      'middleware 2 end',
+      'middleware 1 end',
+    ]);
+    expect(emission).toEqual([
+      'openExternalUrl-event',
+      { openedUrl: 'https://example.com/docs', traced: true },
+    ]);
+  });
+
+  it('short-circuits a blocked request without invoking native code', async () => {
+    const nativeMethod = jest.fn(async () => 'opened');
+    const appBridge = bridge({ openExternalUrl: nativeMethod }).use(
+      (request, next) => {
+        const [url] = request.args;
+        return typeof url === 'string' && url.startsWith('https://')
+          ? next()
+          : { status: 'blocked' };
+      },
+    );
+
+    const emission = await invokeBridge(appBridge, 'openExternalUrl', [
+      'http://untrusted.example',
+    ]);
+
+    expect(nativeMethod).not.toHaveBeenCalled();
+    expect(emission).toEqual([
+      'openExternalUrl-event',
+      { status: 'blocked' },
+    ]);
+  });
+
+  it('allows outer middleware to recover a native error', async () => {
+    const appBridge = bridge({
+      async loadProfile() {
+        throw new Error('native unavailable');
+      },
+    }).use(async (_request, next) => {
+      try {
+        return await next();
+      } catch (error) {
+        return {
+          recovered: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+
+    const emission = await invokeBridge(appBridge, 'loadProfile');
+
+    expect(emission).toEqual([
+      'loadProfile-event',
+      { recovered: 'native unavailable' },
+    ]);
+  });
+
+  it('isolates bridge instances and snapshots middleware per request', async () => {
+    let releaseRequest!: () => void;
+    const requestGate = new Promise<void>((resolve) => {
+      releaseRequest = resolve;
+    });
+    const firstBridge = bridge({
+      async getValue() {
+        return 'first native value';
+      },
+    }).use(async (_request, next) => {
+      await requestGate;
+      return next();
+    });
+    const secondBridge = bridge({
+      async getValue() {
+        return 'second native value';
+      },
+    });
+
+    const inFlightRequest = invokeBridge(firstBridge, 'getValue');
+    firstBridge.use(() => 'late middleware value');
+    releaseRequest();
+
+    await expect(inFlightRequest).resolves.toEqual([
+      'getValue-event',
+      'first native value',
+    ]);
+    await expect(invokeBridge(firstBridge, 'getValue')).resolves.toEqual([
+      'getValue-event',
+      'late middleware value',
+    ]);
+    await expect(invokeBridge(secondBridge, 'getValue')).resolves.toEqual([
+      'getValue-event',
+      'second native value',
+    ]);
+  });
+
+  it('rejects duplicate and late next calls', async () => {
+    const nativeMethod = jest.fn(async () => 'native value');
+    const duplicateBridge = bridge({ getValue: nativeMethod }).use(
+      async (_request, next) => {
+        await next();
+        return next();
+      },
+    );
+    const consoleError = jest
+      .spyOn(console, 'error')
+      .mockImplementation(() => undefined);
+
+    const duplicateEmission = await invokeBridge(duplicateBridge, 'getValue');
+    const duplicateError = JSON.parse(String(duplicateEmission[2])) as {
+      message: string;
+    };
+
+    expect(nativeMethod).toHaveBeenCalledTimes(1);
+    expect(duplicateError.message).toBe('next() called multiple times');
+
+    let lateNext!: BridgeMiddlewareNext;
+    const lateBridge = bridge({
+      async getValue() {
+        return 'native value';
+      },
+    }).use((_request, next) => {
+      lateNext = next;
+      return 'short-circuited';
+    });
+
+    await expect(invokeBridge(lateBridge, 'getValue')).resolves.toEqual([
+      'getValue-event',
+      'short-circuited',
+    ]);
+    await expect(lateNext()).rejects.toThrow(
+      'next() called after middleware completed',
+    );
+
+    consoleError.mockRestore();
+  });
+});

--- a/example/native-method/react-native/jest.config.js
+++ b/example/native-method/react-native/jest.config.js
@@ -1,3 +1,9 @@
 module.exports = {
   preset: 'react-native',
+  // pnpm keeps React Native sources under node_modules/.pnpm, so include the
+  // real package paths in Babel transformation as well as their symlinks.
+  transformIgnorePatterns: [
+    'node_modules/.pnpm/(?!(react-native|@react-native\\+[^@]+)@)',
+    'node_modules/(?!.pnpm|react-native|@react-native)',
+  ],
 };

--- a/example/native-method/react-native/package.json
+++ b/example/native-method/react-native/package.json
@@ -15,12 +15,13 @@
   },
   "dependencies": {
     "@rnx-kit/metro-config": "^1.3.9",
-    "@webview-bridge/react-native": "1.7.5",
+    "@webview-bridge/react-native": "workspace:*",
     "react": "18.3.1",
     "react-native": "0.76.0",
     "react-native-inappbrowser-reborn": "^3.7.0",
     "react-native-safe-area-context": "^4.11.1",
     "react-native-screens": "^3.34.0",
+    "react-native-url-polyfill": "^4.0.0",
     "react-native-webview": "13.12.0"
   },
   "devDependencies": {
@@ -34,8 +35,11 @@
     "@react-native/eslint-config": "0.76.0",
     "@react-native/metro-config": "0.76.0",
     "@react-native/typescript-config": "0.76.0",
+    "@types/jest": "^29.5.13",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
+    "@typescript-eslint/eslint-plugin": "7.18.0",
+    "@typescript-eslint/parser": "7.18.0",
     "babel-jest": "^29.6.3",
     "eslint": "^8.19.0",
     "jest": "^29.6.3",

--- a/example/native-method/react/README.md
+++ b/example/native-method/react/README.md
@@ -1,50 +1,14 @@
-# React + TypeScript + Vite
+# Native method and middleware web app
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+This Vite app is the WebView UI for the paired React Native example. It sends
+real bridge requests that exercise origin authorization, argument
+normalization, native InAppBrowser launch, and error propagation.
 
-Currently, two official plugins are available:
+See the [React Native example instructions](../react-native/README.md) for the
+complete setup and manual verification flow.
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react/README.md) uses [Babel](https://babeljs.io/) for Fast Refresh
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react-swc) uses [SWC](https://swc.rs/) for Fast Refresh
+From the repository root, start only the web app with:
 
-## Expanding the ESLint configuration
-
-If you are developing a production application, we recommend updating the configuration to enable type aware lint rules:
-
-- Configure the top-level `parserOptions` property like this:
-
-```js
-export default tseslint.config({
-  languageOptions: {
-    // other options...
-    parserOptions: {
-      project: ['./tsconfig.node.json', './tsconfig.app.json'],
-      tsconfigRootDir: import.meta.dirname,
-    },
-  },
-})
-```
-
-- Replace `tseslint.configs.recommended` to `tseslint.configs.recommendedTypeChecked` or `tseslint.configs.strictTypeChecked`
-- Optionally add `...tseslint.configs.stylisticTypeChecked`
-- Install [eslint-plugin-react](https://github.com/jsx-eslint/eslint-plugin-react) and update the config:
-
-```js
-// eslint.config.js
-import react from 'eslint-plugin-react'
-
-export default tseslint.config({
-  // Set the react version
-  settings: { react: { version: '18.3' } },
-  plugins: {
-    // Add the react plugin
-    react,
-  },
-  rules: {
-    // other rules...
-    // Enable its recommended rules
-    ...react.configs.recommended.rules,
-    ...react.configs['jsx-runtime'].rules,
-  },
-})
+```bash
+pnpm --filter @webview-bridge-example-native-method/react dev
 ```

--- a/example/native-method/react/src/App.tsx
+++ b/example/native-method/react/src/App.tsx
@@ -1,10 +1,12 @@
 import { useEffect, useState } from "react";
-import "./App.css";
 import { linkBridge } from "@webview-bridge/web";
 import type { AppBridge } from "@webview-bridge-example-native-method/react-native/types";
+import "./App.css";
 
 const bridge = linkBridge<AppBridge>({
   throwOnError: true,
+  // InAppBrowser.open resolves only after the native browser closes.
+  timeout: 0,
   onReady: () => {
     console.log("bridge is ready");
   },
@@ -13,58 +15,195 @@ const bridge = linkBridge<AppBridge>({
   },
 });
 
+type BrowserResult = Awaited<
+  ReturnType<typeof bridge.openInAppBrowser>
+> & {
+  requestedUrl: string;
+  roundTripMs: number;
+};
+
+type RequestStatus = {
+  kind: "idle" | "success" | "error";
+  message: string;
+};
+
+const getErrorMessage = (error: unknown) =>
+  error instanceof Error ? error.message : String(error);
+
 function App() {
-  const [message, setMessage] = useState("");
-  const [errorMessage, setErrorMessage] = useState("");
+  const [nativeMessage, setNativeMessage] = useState("Connecting...");
+  const [externalUrl, setExternalUrl] = useState(
+    "github.com/gronxb/webview-bridge",
+  );
+  const [browserResult, setBrowserResult] = useState<BrowserResult>();
+  const [requestStatus, setRequestStatus] = useState<RequestStatus>({
+    kind: "idle",
+    message: "Use the form to send a real request through the middleware chain.",
+  });
+  const [pending, setPending] = useState(false);
 
   useEffect(() => {
-    async function init() {
-      const message = await bridge.getMessage();
-      setMessage(message);
+    async function loadNativeMessage() {
+      try {
+        setNativeMessage(await bridge.getMessage());
+      } catch (error) {
+        setNativeMessage(`Bridge error: ${getErrorMessage(error)}`);
+      }
     }
 
-    init();
+    void loadNativeMessage();
   }, []);
 
+  const openExternalUrl = async (requestedUrl: string) => {
+    setPending(true);
+    setBrowserResult(undefined);
+    const startedAt = performance.now();
+
+    try {
+      const result = await bridge.openInAppBrowser(requestedUrl);
+      setBrowserResult({
+        ...result,
+        requestedUrl,
+        roundTripMs: Math.round(performance.now() - startedAt),
+      });
+      setRequestStatus({
+        kind: "success",
+        message:
+          result.status === "unavailable"
+            ? "InAppBrowser is unavailable on this device."
+            : "InAppBrowser opened the normalized URL and returned after it closed.",
+      });
+    } catch (error) {
+      setRequestStatus({
+        kind: "error",
+        message: getErrorMessage(error),
+      });
+    } finally {
+      setPending(false);
+    }
+  };
+
+  const requestNativeError = async () => {
+    setPending(true);
+    setBrowserResult(undefined);
+    try {
+      await bridge.throwError();
+      setRequestStatus({
+        kind: "error",
+        message: "Expected a native error, but the request resolved.",
+      });
+    } catch (error) {
+      setRequestStatus({
+        kind: "error",
+        message: getErrorMessage(error),
+      });
+    } finally {
+      setPending(false);
+    }
+  };
+
   return (
-    <div>
-      <h1>This is a web page.</h1>
-      <h1>{message}</h1>
-      <button
-        onClick={() => {
-          if (bridge.isNativeMethodAvailable("openInAppBrowser") === true) {
-            bridge.openInAppBrowser("https://github.com/gronxb/webview-bridge");
-          }
-        }}
-      >
-        open InAppBrowser
-      </button>
+    <main className="app">
+      <header>
+        <p className="eyebrow">@webview-bridge middleware example</p>
+        <h1>Secure external links</h1>
+        <p className="lede">
+          This request passes through logging, WebView-origin authorization,
+          and HTTPS URL normalization before native code runs.
+        </p>
+      </header>
 
-      <button
-        style={{ marginTop: 8 }}
-        onClick={async () => {
-          try {
-            await bridge.throwError();
-          } catch (err) {
-            if (err instanceof Error) {
-              setErrorMessage(err.message);
-            }
-          }
-        }}
-      >
-        Test Error from Native
-      </button>
-
-      {errorMessage && (
-        <div style={{ marginTop: 16, padding: 12, background: "#fee", border: "1px solid red" }}>
-          <strong>Error caught: </strong>{errorMessage}
+      <section className="panel connection" aria-label="Bridge connection">
+        <span
+          className={`dot ${bridge.isWebViewBridgeAvailable ? "online" : ""}`}
+        />
+        <div>
+          <strong>{nativeMessage}</strong>
+          <small>
+            Bridge available: {String(bridge.isWebViewBridgeAvailable)}
+          </small>
         </div>
-      )}
+      </section>
 
-      <div>
-        {`isWebViewBridgeAvailable: ${String(bridge.isWebViewBridgeAvailable)}`}
-      </div>
-    </div>
+      <section className="panel">
+        <h2>Open an HTTPS link</h2>
+        <form
+          onSubmit={(event) => {
+            event.preventDefault();
+            void openExternalUrl(externalUrl);
+          }}
+        >
+          <label htmlFor="external-url">External URL</label>
+          <input
+            id="external-url"
+            value={externalUrl}
+            onChange={(event) => setExternalUrl(event.target.value)}
+            placeholder="github.com/gronxb/webview-bridge"
+            autoCapitalize="none"
+            autoCorrect="off"
+          />
+          <p className="hint">
+            The native middleware trims this value, adds https:// when needed,
+            and rejects every non-HTTPS scheme.
+          </p>
+
+          <div className="actions">
+            <button type="submit" disabled={pending}>
+              {pending ? "Running..." : "Open with middleware"}
+            </button>
+            <button
+              className="secondary"
+              type="button"
+              disabled={pending}
+              onClick={() => {
+                const unsafeUrl = "javascript:alert('blocked')";
+                setExternalUrl(unsafeUrl);
+                void openExternalUrl(unsafeUrl);
+              }}
+            >
+              Try blocked scheme
+            </button>
+          </div>
+        </form>
+      </section>
+
+      <section
+        className={`panel status ${requestStatus.kind}`}
+        aria-live="polite"
+      >
+        <h2>Latest bridge result</h2>
+        <p>{requestStatus.message}</p>
+        {browserResult && (
+          <dl>
+            <div>
+              <dt>Requested</dt>
+              <dd>{browserResult.requestedUrl}</dd>
+            </div>
+            <div>
+              <dt>Normalized by native</dt>
+              <dd>{browserResult.openedUrl}</dd>
+            </div>
+            <div>
+              <dt>Browser result</dt>
+              <dd>{browserResult.status}</dd>
+            </div>
+            <div>
+              <dt>Native call duration (includes browser)</dt>
+              <dd>{browserResult.roundTripMs}ms</dd>
+            </div>
+          </dl>
+        )}
+      </section>
+
+      <button
+        className="text-button"
+        type="button"
+        disabled={pending}
+        onClick={() => void requestNativeError()}
+      >
+        Verify native error propagation
+      </button>
+    </main>
   );
 }
 

--- a/example/native-method/react/src/bridgeStore.type-test.ts
+++ b/example/native-method/react/src/bridgeStore.type-test.ts
@@ -1,0 +1,9 @@
+import { linkBridge } from "@webview-bridge/web";
+import type { AppBridge } from "@webview-bridge-example-native-method/react-native/types";
+
+type Assert<T extends true> = T;
+type LinkedAppBridge = ReturnType<typeof linkBridge<AppBridge>>;
+
+export type BridgeStoreDoesNotExposeNativeMiddleware = Assert<
+  "use" extends keyof LinkedAppBridge["store"] ? false : true
+>;

--- a/packages/react-native/src/createWebView.tsx
+++ b/packages/react-native/src/createWebView.tsx
@@ -215,12 +215,13 @@ export const createWebView = <
       useImperativeHandle(ref, () => webviewRef.current as BridgeWebView, []);
 
       const handleMessage = async (event: WebViewMessageEvent) => {
+        const { data, url } = event.nativeEvent;
         props.onMessage?.(event);
 
         if (!webviewRef.current) {
           return;
         }
-        const { type, body, bridgeId } = JSON.parse(event.nativeEvent.data);
+        const { type, body, bridgeId } = JSON.parse(data);
 
         switch (type) {
           case "log": {
@@ -245,6 +246,7 @@ export const createWebView = <
               args,
               eventId,
               webview: webviewRef.current,
+              url,
             });
             return;
           }

--- a/packages/react-native/src/integrations/bridge.ts
+++ b/packages/react-native/src/integrations/bridge.ts
@@ -8,6 +8,45 @@ import { equals, removeUndefinedKeys } from "@webview-bridge/utils";
 import type WebView from "react-native-webview";
 import { serializeError } from "../error";
 
+/**
+ * A Web-to-Native bridge method request passed through bridge middleware.
+ *
+ * `url` is the current top-level WebView URL reported by
+ * `react-native-webview`. It is not a verified origin for the frame that sent
+ * the request. Context fields added by middleware are shared with downstream
+ * middleware in the same request.
+ */
+type BridgeRequestBase = {
+  readonly url?: string;
+  readonly method: string;
+  args: unknown[];
+};
+
+export type BridgeRequest<Context extends object = object> = BridgeRequestBase &
+  Context;
+
+/** Continue to the next middleware or native method. Await or return it. */
+export type BridgeMiddlewareNext = () => Promise<unknown>;
+
+export type BridgeMiddleware<Context extends object = object> = (
+  request: BridgeRequest<Context>,
+  next: BridgeMiddlewareNext,
+) => unknown | Promise<unknown>;
+
+export type BridgeMiddlewareBuilder<
+  T extends Bridge,
+  Context extends object = object,
+> = {
+  /**
+   * Add middleware to this bridge instance's Web-to-Native request pipeline.
+   */
+  use<AddedContext extends object = object>(
+    middleware: BridgeMiddleware<Context & AddedContext>,
+  ): BridgeStore<T> & BridgeMiddlewareBuilder<T, Context & AddedContext>;
+};
+
+const bridgeMiddlewareMap = new WeakMap<object, BridgeMiddleware<object>[]>();
+
 export type StoreCallback<T> = ({
   get,
   set,
@@ -18,7 +57,7 @@ export type StoreCallback<T> = ({
 
 export const bridge = <T extends Bridge>(
   procedures: T | StoreCallback<T>,
-): BridgeStore<T> => {
+): BridgeStore<T> & BridgeMiddlewareBuilder<T, object> => {
   const getState = () => state;
 
   const setState = (newState: Partial<OnlyJSON<T>>) => {
@@ -57,11 +96,28 @@ export const bridge = <T extends Bridge>(
     return () => listeners.delete(listener);
   };
 
-  return {
+  const middlewares: BridgeMiddleware<object>[] = [];
+  const store: BridgeStore<T> = {
     getState,
     setState,
     subscribe,
-  } as BridgeStore<T>;
+  };
+  const middlewareStore = store as BridgeStore<T> &
+    BridgeMiddlewareBuilder<T, object>;
+
+  Object.defineProperty(store, "use", {
+    enumerable: false,
+    value(middleware: BridgeMiddleware<object>) {
+      if (typeof middleware !== "function") {
+        throw new TypeError("Bridge middleware must be a function");
+      }
+      middlewares.push(middleware);
+      return middlewareStore;
+    },
+  });
+
+  bridgeMiddlewareMap.set(store, middlewares);
+  return middlewareStore;
 };
 
 type HandleBridgeArgs<ArgType = unknown> = {
@@ -71,6 +127,70 @@ type HandleBridgeArgs<ArgType = unknown> = {
   webview: WebView;
   eventId: string;
   bridgeId: string;
+  url?: string;
+};
+
+const runBridgeMiddleware = async (
+  bridgeStore: BridgeStore<Bridge>,
+  request: BridgeRequest,
+  invokeMethod: () => Promise<unknown>,
+) => {
+  const middlewares = [...(bridgeMiddlewareMap.get(bridgeStore) ?? [])];
+
+  const dispatch = async (index: number): Promise<unknown> => {
+    const middleware = middlewares[index];
+    if (!middleware) {
+      return invokeMethod();
+    }
+
+    const nextState: {
+      status: "not-called" | "pending" | "fulfilled" | "rejected";
+      value?: unknown;
+    } = { status: "not-called" };
+    let nextCalled = false;
+    let active = true;
+    const next = () => {
+      if (!active) {
+        const rejection = Promise.reject(
+          new Error("next() called after middleware completed"),
+        );
+        void rejection.catch(() => {});
+        return rejection;
+      }
+      if (nextCalled) {
+        throw new Error("next() called multiple times");
+      }
+      nextCalled = true;
+      nextState.status = "pending";
+      const nextPromise = dispatch(index + 1).then(
+        (value) => {
+          nextState.status = "fulfilled";
+          nextState.value = value;
+          return value;
+        },
+        (error) => {
+          nextState.status = "rejected";
+          throw error;
+        },
+      );
+      void nextPromise.catch(() => {});
+      return nextPromise;
+    };
+
+    let result: unknown;
+    try {
+      result = await middleware(request, next);
+    } finally {
+      active = false;
+    }
+
+    if (result === undefined && nextState.status === "fulfilled") {
+      return nextState.value;
+    }
+    return result;
+  };
+
+  return dispatch(0);
 };
 
 export const handleBridge = async ({
@@ -80,6 +200,7 @@ export const handleBridge = async ({
   webview,
   eventId,
   bridgeId,
+  url,
 }: HandleBridgeArgs) => {
   const _bridge = bridge.getState();
 
@@ -103,7 +224,14 @@ export const handleBridge = async ({
   }
 
   try {
-    const response = await _method?.(...(args ?? []));
+    const request: BridgeRequest = {
+      url,
+      method,
+      args: args ?? [],
+    };
+    const response = await runBridgeMiddleware(bridge, request, () =>
+      _method(...request.args),
+    );
 
     webview.injectJavaScript(
       SAFE_NATIVE_EMITTER_EMIT_BY_BRIDGE_ID(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -103,8 +103,8 @@ importers:
         specifier: ^1.3.9
         version: 1.3.9(@babel/core@7.25.9)(@babel/plugin-transform-typescript@7.25.9(@babel/core@7.25.9))(@react-native/metro-config@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9)))(metro-config@0.81.0)(metro-react-native-babel-preset@0.76.8(@babel/core@7.25.9))(metro-resolver@0.81.0)(react-native@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
       '@webview-bridge/react-native':
-        specifier: 1.7.5
-        version: 1.7.5(react-native-webview@13.12.0(react-native@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1))(react@18.3.1)
+        specifier: workspace:*
+        version: link:../../../packages/react-native
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -120,6 +120,9 @@ importers:
       react-native-screens:
         specifier: ^3.34.0
         version: 3.34.0(react-native@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
+      react-native-url-polyfill:
+        specifier: ^4.0.0
+        version: 4.0.0(react-native@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1))
       react-native-webview:
         specifier: 13.12.0
         version: 13.12.0(react-native@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1))(react@18.3.1)
@@ -154,12 +157,21 @@ importers:
       '@react-native/typescript-config':
         specifier: 0.76.0
         version: 0.76.0
+      '@types/jest':
+        specifier: ^29.5.13
+        version: 29.5.14
       '@types/react':
         specifier: ^18.2.6
         version: 18.3.12
       '@types/react-test-renderer':
         specifier: ^18.0.0
         version: 18.0.3
+      '@typescript-eslint/eslint-plugin':
+        specifier: 7.18.0
+        version: 7.18.0(@typescript-eslint/parser@7.18.0(eslint@8.51.0)(typescript@5.6.3))(eslint@8.51.0)(typescript@5.6.3)
+      '@typescript-eslint/parser':
+        specifier: 7.18.0
+        version: 7.18.0(eslint@8.51.0)(typescript@5.6.3)
       babel-jest:
         specifier: ^29.6.3
         version: 29.7.0(@babel/core@7.25.9)
@@ -2173,10 +2185,6 @@ packages:
     resolution: {integrity: sha512-m4DVN9ZqskZoLU5GlWZadwDnYo3vAEydiUayB9widCl9ffWx2IvPnp6n3on5rJmziJSw9Bv+Z3ChDVdMwXCY8Q==}
     engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
 
-  '@eslint-community/regexpp@4.9.1':
-    resolution: {integrity: sha512-Y27x+MBLjXa+0JWDhykM3+JE+il3kHKAEqabfEWq3SDhZjLYb6/BHL/JKFnH3fe207JaXkyDo685Oc2Glt6ifA==}
-    engines: {node: ^12.0.0 || ^14.0.0 || >=16.0.0}
-
   '@eslint/config-array@0.18.0':
     resolution: {integrity: sha512-fTxvnS1sRMu3+JjXwJG0j/i4RT9u4qJ+lqS/yCGap4lH4zZGzQ7tu+xZqQmcMZq5OBZDL4QRxQzRjkWcGt8IVw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
@@ -2185,8 +2193,8 @@ packages:
     resolution: {integrity: sha512-xp5Jirz5DyPYlPiKat8jaq0EmYvDXKKpzTbxXMpT9eqlRJkRKIz9AGMdlvYjih+im+QlhWrpvVjl8IPC/lHlUw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
 
-  '@eslint/eslintrc@2.1.2':
-    resolution: {integrity: sha512-+wvgpDsrB1YqAMdEUCcnTlpfVBH7Vqn6A/NT3D8WVXFIaKMlErPIZT3oCIAVCOtarRpMtelZLqJeU3t7WY6X6g==}
+  '@eslint/eslintrc@2.1.4':
+    resolution: {integrity: sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
   '@eslint/eslintrc@3.1.0':
@@ -3241,6 +3249,9 @@ packages:
   '@types/istanbul-reports@3.0.2':
     resolution: {integrity: sha512-kv43F9eb3Lhj+lr/Hn6OcLCs/sSM8bt+fIaP11rCYngfV6NVjzWXJ17owQtDQTL9tQ8WSLUrGsSJ6rJz0F1w1A==}
 
+  '@types/jest@29.5.14':
+    resolution: {integrity: sha512-ZN+4sdnLUbo8EVvVc2ao0GFW6oVrQRPn4K2lglySj7APvSrgzxHiNNK99us4WDMi57xxA2yggblIAMNhXOotLQ==}
+
   '@types/json-schema@7.0.15':
     resolution: {integrity: sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==}
 
@@ -3668,11 +3679,6 @@ packages:
   acorn-walk@8.3.4:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
-
-  acorn@8.10.0:
-    resolution: {integrity: sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
 
   acorn@8.13.0:
     resolution: {integrity: sha512-8zSiw54Oxrdym50NlZ9sUusyO1Z1ZchgRLWRaK6c86XJFClyCgFKetdowBg5bKxyp/u+CDBJG4Mpp0m3HLZl9w==}
@@ -4910,10 +4916,6 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
-  ignore@5.2.4:
-    resolution: {integrity: sha512-MAb38BcSbH0eHNBxn7ql2NH/kX33OkB3lZ1BNdh7ENeRChHTYsTvWrMubiIAMNS2llXEEgZ1MUOBtXChP3kaFQ==}
-    engines: {node: '>= 4'}
-
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
     engines: {node: '>= 4'}
@@ -6075,6 +6077,11 @@ packages:
     resolution: {integrity: sha512-8ri3Pd9QcpfXnVckOe/Lnto+BXmSPHV/Q0RB0XW0gDKsCv5wi5k7ez7g1SzgiYHl29MSdiqgjH30zUyOOowOaw==}
     peerDependencies:
       react: '*'
+      react-native: '*'
+
+  react-native-url-polyfill@4.0.0:
+    resolution: {integrity: sha512-eqYM3wBAA0eL1sPYbBAoNfbES3+NkgcxUdelQ7QzmoVtqKB5qGG0U13MPTRUroAWK+y2EoJFS3MZUK0fwTf0pA==}
+    peerDependencies:
       react-native: '*'
 
   react-native-webview@13.12.0:
@@ -7246,7 +7253,7 @@ snapshots:
       '@babel/core': 7.25.9
       '@babel/helper-compilation-targets': 7.25.9
       '@babel/helper-plugin-utils': 7.25.9
-      debug: 4.3.7
+      debug: 4.4.0
       lodash.debounce: 4.0.8
       resolve: 1.22.6
     transitivePeerDependencies:
@@ -8473,8 +8480,6 @@ snapshots:
 
   '@eslint-community/regexpp@4.11.1': {}
 
-  '@eslint-community/regexpp@4.9.1': {}
-
   '@eslint/config-array@0.18.0':
     dependencies:
       '@eslint/object-schema': 2.1.4
@@ -8485,15 +8490,15 @@ snapshots:
 
   '@eslint/core@0.7.0': {}
 
-  '@eslint/eslintrc@2.1.2':
+  '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.3.4
+      debug: 4.4.0
       espree: 9.6.1
       globals: 13.23.0
-      ignore: 5.2.4
+      ignore: 5.3.2
       import-fresh: 3.3.0
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       minimatch: 3.1.2
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
@@ -8539,7 +8544,7 @@ snapshots:
   '@humanwhocodes/config-array@0.11.11':
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
-      debug: 4.3.4
+      debug: 4.4.0
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -9794,6 +9799,11 @@ snapshots:
     dependencies:
       '@types/istanbul-lib-report': 3.0.1
 
+  '@types/jest@29.5.14':
+    dependencies:
+      expect: 29.7.0
+      pretty-format: 29.7.0
+
   '@types/json-schema@7.0.15': {}
 
   '@types/linkify-it@3.0.5': {}
@@ -9910,7 +9920,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7
+      debug: 4.4.0
       eslint: 8.51.0
     optionalDependencies:
       typescript: 5.6.3
@@ -9923,7 +9933,7 @@ snapshots:
       '@typescript-eslint/types': 8.11.0
       '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.6.3)
       '@typescript-eslint/visitor-keys': 8.11.0
-      debug: 4.3.7
+      debug: 4.4.0
       eslint: 9.13.0(jiti@1.21.6)
     optionalDependencies:
       typescript: 5.6.3
@@ -9949,7 +9959,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@5.6.3)
       '@typescript-eslint/utils': 7.18.0(eslint@8.51.0)(typescript@5.6.3)
-      debug: 4.3.7
+      debug: 4.4.0
       eslint: 8.51.0
       ts-api-utils: 1.3.0(typescript@5.6.3)
     optionalDependencies:
@@ -9961,7 +9971,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 8.11.0(typescript@5.6.3)
       '@typescript-eslint/utils': 8.11.0(eslint@9.13.0(jiti@1.21.6))(typescript@5.6.3)
-      debug: 4.3.7
+      debug: 4.4.0
       ts-api-utils: 1.3.0(typescript@5.6.3)
     optionalDependencies:
       typescript: 5.6.3
@@ -9979,7 +9989,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.3.7
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.6.3
@@ -9993,7 +10003,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.3.7
+      debug: 4.4.0
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -10008,7 +10018,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.11.0
       '@typescript-eslint/visitor-keys': 8.11.0
-      debug: 4.3.7
+      debug: 4.4.0
       fast-glob: 3.3.2
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -10331,10 +10341,6 @@ snapshots:
       mime-types: 2.1.35
       negotiator: 0.6.3
 
-  acorn-jsx@5.3.2(acorn@8.10.0):
-    dependencies:
-      acorn: 8.10.0
-
   acorn-jsx@5.3.2(acorn@8.13.0):
     dependencies:
       acorn: 8.13.0
@@ -10342,8 +10348,6 @@ snapshots:
   acorn-walk@8.3.4:
     dependencies:
       acorn: 8.13.0
-
-  acorn@8.10.0: {}
 
   acorn@8.13.0: {}
 
@@ -11279,16 +11283,16 @@ snapshots:
   eslint@8.51.0:
     dependencies:
       '@eslint-community/eslint-utils': 4.4.0(eslint@8.51.0)
-      '@eslint-community/regexpp': 4.9.1
-      '@eslint/eslintrc': 2.1.2
+      '@eslint-community/regexpp': 4.11.1
+      '@eslint/eslintrc': 2.1.4
       '@eslint/js': 8.51.0
       '@humanwhocodes/config-array': 0.11.11
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6
       chalk: 4.1.2
-      cross-spawn: 7.0.3
-      debug: 4.3.4
+      cross-spawn: 7.0.6
+      debug: 4.4.0
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -11302,11 +11306,11 @@ snapshots:
       glob-parent: 6.0.2
       globals: 13.23.0
       graphemer: 1.4.0
-      ignore: 5.2.4
+      ignore: 5.3.2
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.0
+      js-yaml: 4.1.1
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
@@ -11368,8 +11372,8 @@ snapshots:
 
   espree@9.6.1:
     dependencies:
-      acorn: 8.10.0
-      acorn-jsx: 5.3.2(acorn@8.10.0)
+      acorn: 8.13.0
+      acorn-jsx: 5.3.2(acorn@8.13.0)
       eslint-visitor-keys: 3.4.3
 
   esprima@4.0.1: {}
@@ -11770,8 +11774,6 @@ snapshots:
 
   ieee754@1.2.1: {}
 
-  ignore@5.2.4: {}
-
   ignore@5.3.2: {}
 
   image-size@1.0.2:
@@ -11973,7 +11975,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.0
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -13322,6 +13324,10 @@ snapshots:
       react-freeze: 1.0.4(react@18.3.1)
       react-native: 0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1)
       warn-once: 0.1.1
+
+  react-native-url-polyfill@4.0.0(react-native@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1)):
+    dependencies:
+      react-native: 0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.3.12)(react@18.3.1)
 
   react-native-webview@13.12.0(react-native@0.76.0(@babel/core@7.25.9)(@babel/preset-env@7.25.9(@babel/core@7.25.9))(@react-native-community/cli-server-api@13.6.9)(@types/react@18.2.25)(react@18.3.1))(react@18.3.1):
     dependencies:


### PR DESCRIPTION
## Summary

- add instance-scoped `bridge(...).use(middleware)` chaining to `@webview-bridge/react-native`
- run Web-to-Native method calls through an onion-style pipeline supporting typed context propagation, argument preprocessing, short-circuiting, response transforms, and error recovery
- snapshot middleware per request and reject duplicate or late `next()` calls
- preserve existing `BridgeStore<T>` compatibility; `use` is a non-enumerable additive capability and the legacy store shape is unchanged when middleware is not used
- document and exercise the API in the existing native-method example, using `react-native-url-polyfill` for URL parsing while leaving `@webview-bridge/web` and the existing web CSS unchanged

## Example

```tsx
const appBridge = bridge({
  async getMessage() {
    return "Hello from native";
  },
})
  .use(auth())
  .use(logger());
```

Middleware receives a shared `{ url, method, args, ...context }` request and a `next()` function. Middleware is isolated per bridge instance and runs in registration order before the native method, then unwinds in reverse order.

## Validation

- 6 middleware integration and legacy `BridgeStore` compatibility tests passed
- React Native package type check, build, and Biome check passed
- React Native example type check and targeted ESLint check passed
- web example type check and production build passed against the unchanged `@webview-bridge/web@1.7.2`
- verified HTTPS normalization, blocked schemes, and the real InAppBrowser open/close result on iOS 26.5 Simulator and Android 14 / API 34 Emulator

## Notes

`request.url` is the top-level URL reported by `react-native-webview`, not a verified caller origin. It does not identify an iframe or intercept navigation and network requests; the documentation describes this boundary explicitly.

The `pkg.pr.new` preview check fails because the pkg.pr.new GitHub App is not installed on `gronxb/webview-bridge`; package builds complete successfully before that external publishing step.
